### PR TITLE
Support of slash character in zone names.

### DIFF
--- a/templates/zones.conf.erb
+++ b/templates/zones.conf.erb
@@ -2,7 +2,7 @@
 # see man 5 knot.conf for all available configuration options
 <%- @zones.each do |k,v| -%>
 <%= k -%> {
-  file "<%= k -%>.zone";
+  file "<%= k.gsub(/\//, "_") -%>.zone";
 <%- if (@zone_defaults && v && v.length > 0) then _v = @zone_defaults.merge(v) -%>
 <%- elsif (v && v.length > 0) then _v = v -%>
 <%- elsif (@zone_defaults && @zone_defaults.length > 0) then _v = @zone_defaults -%>


### PR DESCRIPTION
When you configure a reverse zone with range (eg 24/0.168.192.in-addr.arpa.) the default zone filename inherits slash and file cannot be found by server.

This update replaces all "/" in zone name by "_".
